### PR TITLE
Don't require authentication for Cloud Run service

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -60,7 +60,8 @@ steps:
       gcloud run deploy "${_APP}-dev-pr${_PR_NUMBER}" \
           --image="${_DEV_IMG}:${_TAG}" \
           --region="${_REGION_US01}" \
-          --ingress=internal-and-cloud-load-balancing
+          --ingress=internal-and-cloud-load-balancing \
+          --allow-unauthenticated \
 
   ###
   ## Promote image to release repo


### PR DESCRIPTION
The service is not publicy accessible over the Internet, but it doesn't
required auth from the end-user via the LB.